### PR TITLE
ci(connect): Use correct version of ko setup action

### DIFF
--- a/.github/workflows/build-connect-container.yml
+++ b/.github/workflows/build-connect-container.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           go-version: '1.22.x'
           cache-dependency-path: ./connect/go.mod
-      - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa #v0.6
+      # use a specific commit of the ko-build/setup-ko action that includes lower casing of docker repo name.
+      - uses: ko-build/setup-ko@f6bcbe6bd48f22c3dc2f08049d856cf0fc719d96 #v0.6 + latest commits as of 2024-04-12
       - run: ko build ./cmd/connect --base-import-paths
         working-directory: ./connect


### PR DESCRIPTION
Use a version that lower cases the docker repo so that it can actually push. This isn't yet included in the latest release